### PR TITLE
Fix with_items statements for ansible 2.2

### DIFF
--- a/tasks/configs.yml
+++ b/tasks/configs.yml
@@ -7,6 +7,6 @@
     owner: root
     group: "{{ elao_bind_group }}"
     mode:  0644
-  with_items: elao_bind_configs
+  with_items: '{{ elao_bind_configs }}'
   notify:
     - bind restart

--- a/tasks/zones.yml
+++ b/tasks/zones.yml
@@ -14,6 +14,6 @@
     owner: root
     group: "{{ elao_bind_group }}"
     mode:  0644
-  with_items: elao_bind_zones
+  with_items: '{{ elao_bind_zones }}'
   notify:
     - bind restart


### PR DESCRIPTION
In ansible 2.2 (and maybe lower versions), it is necessary
that for lists from variables the syntax
with_items: '{{ variable }}'
is used. Otherwise operations like item.property try
to work on the complete list and not a single elements
which causes the error message that property "property" does
not exists on the element "item".